### PR TITLE
未実装のコマンドをグレーアウト

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,9 +6,9 @@ pub trait CommandHandler<C> {
     fn handle_command(&self, command: &C);
 }
 
-pub enum EditorCommand<'a> {
+pub enum EditorCommand<'a, ET> {
     Command(Command),
-    StandardEvents(&'a wx::CommandEvent),
+    StandardEvents(&'a ET),
 }
 
 #[derive(Clone, Copy)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use std::os::raw::c_int;
 use wx;
 
 pub trait CommandHandler<C> {
-    fn handle_command(&mut self, command: &C);
+    fn handle_command(&self, command: &C);
 }
 
 pub enum EditorCommand<'a> {

--- a/src/editor_ctrl.rs
+++ b/src/editor_ctrl.rs
@@ -76,8 +76,8 @@ impl EditorCtrl {
         self.ctrl.set_modified(false);
     }
 }
-impl<'a> CommandHandler<EditorCommand<'a>> for EditorCtrl {
-    fn handle_command(&self, editor_command: &EditorCommand<'a>) {
+impl<'a> CommandHandler<EditorCommand<'a, wx::CommandEvent>> for EditorCtrl {
+    fn handle_command(&self, editor_command: &EditorCommand<'a, wx::CommandEvent>) {
         match editor_command {
             EditorCommand::Command(command) => match command {
                 Command::EditDelete => {

--- a/src/editor_ctrl.rs
+++ b/src/editor_ctrl.rs
@@ -14,17 +14,17 @@ pub enum DocumentEvent {
 
 pub trait Document {
     fn events(&self) -> Rc<RefCell<Subject<DocumentEvent>>>;
-    fn new_file(&mut self);
+    fn new_file(&self);
     fn path(&self) -> Option<String>;
     fn is_modified(&self) -> bool;
-    fn load_from(&mut self, file_path: &str);
-    fn save_to(&mut self, file_path: &str) -> bool;
+    fn load_from(&self, file_path: &str);
+    fn save_to(&self, file_path: &str) -> bool;
 }
 
 pub struct EditorCtrl {
     ctrl: wx::TextCtrl,
     events: Rc<RefCell<Subject<DocumentEvent>>>,
-    pub file: Option<String>,
+    pub file: Rc<RefCell<Option<String>>>,
 }
 impl EditorCtrl {
     pub fn new<W: WindowMethods>(parent: &W) -> Self {
@@ -49,7 +49,7 @@ impl EditorCtrl {
         Self {
             ctrl: textbox,
             events,
-            file: None,
+            file: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -67,12 +67,12 @@ impl EditorCtrl {
         self.ctrl.select_all();
     }
 
-    fn set_path(&mut self, path: Option<&str>) {
-        self.file = path.map(ToOwned::to_owned);
+    fn set_path(&self, path: Option<&str>) {
+        *self.file.borrow_mut() = path.map(ToOwned::to_owned);
         self.reset_modified();
     }
 
-    fn reset_modified(&mut self) {
+    fn reset_modified(&self) {
         self.ctrl.set_modified(false);
     }
 }
@@ -101,21 +101,21 @@ impl Document for EditorCtrl {
     fn events(&self) -> Rc<RefCell<Subject<DocumentEvent>>> {
         self.events.clone()
     }
-    fn new_file(&mut self) {
+    fn new_file(&self) {
         self.ctrl.clear();
         self.set_path(None);
     }
     fn path(&self) -> Option<String> {
-        self.file.clone()
+        self.file.borrow().clone()
     }
     fn is_modified(&self) -> bool {
         self.ctrl.is_modified()
     }
-    fn load_from(&mut self, file_path: &str) {
+    fn load_from(&self, file_path: &str) {
         self.ctrl.load_file(file_path, wx::TEXT_TYPE_ANY);
         self.set_path(Some(&file_path));
     }
-    fn save_to(&mut self, file_path: &str) -> bool {
+    fn save_to(&self, file_path: &str) -> bool {
         let result = self.ctrl.save_file(file_path, wx::TEXT_TYPE_ANY);
         self.set_path(Some(file_path));
         result

--- a/src/editor_ctrl.rs
+++ b/src/editor_ctrl.rs
@@ -77,7 +77,7 @@ impl EditorCtrl {
     }
 }
 impl<'a> CommandHandler<EditorCommand<'a>> for EditorCtrl {
-    fn handle_command(&mut self, editor_command: &EditorCommand<'a>) {
+    fn handle_command(&self, editor_command: &EditorCommand<'a>) {
         match editor_command {
             EditorCommand::Command(command) => match command {
                 Command::EditDelete => {

--- a/src/editor_frame.rs
+++ b/src/editor_frame.rs
@@ -59,17 +59,6 @@ impl EditorFrame {
             .borrow()
             .base
             .bind(wx::RustEvent::UpdateUI, move |event: &wx::UpdateUIEvent| {
-                // wx::EvtHandler のユーザーデータとして EditorFrame を引き渡して、
-                // 各イベントハンドラで borrow_mut() しなくていいようにすることを考えた。
-                // しかし、結局その後 EditorFrame への参照を使いたいので
-                // 所有権を渡してしまうわけにいかない。
-                // 結局 Rc<RefCell<>> などを渡すのであれば、各イベントハンドラの箇所で
-                // borrow_mut() をせねばならず、問題が解決しない。
-                // イベントハンドラが入れ子になることは避けられない。
-                // 幾つかの典型的なイベント処理は同期的でなくてもよいために、
-                // 処理の実行を１イベント分遅らせることで問題を回避できる。
-                // 一方で、CloseWindow, UpdateUI などその場で判定を求められる類のイベントハンドラは
-                // 処理を遅延させることが困難である。
                 frame_copy.borrow().on_update_ui(&event);
             });
         let frame_copy = frame.clone();

--- a/src/editor_frame.rs
+++ b/src/editor_frame.rs
@@ -70,14 +70,14 @@ impl EditorFrame {
                 // 処理の実行を１イベント分遅らせることで問題を回避できる。
                 // 一方で、CloseWindow, UpdateUI などその場で判定を求められる類のイベントハンドラは
                 // 処理を遅延させることが困難である。
-                frame_copy.borrow_mut().on_update_ui(&event);
+                frame_copy.borrow().on_update_ui(&event);
             });
         let frame_copy = frame.clone();
         frame
             .borrow()
             .base
             .bind(wx::RustEvent::CloseWindow, move |event: &wx::CloseEvent| {
-                frame_copy.borrow_mut().on_close(&event);
+                frame_copy.borrow().on_close(&event);
             });
         frame.borrow().build_menu();
         frame.borrow().update_title();
@@ -137,8 +137,8 @@ impl EditorFrame {
         self.base.set_menu_bar(Some(&menu_bar));
     }
 
-    pub fn new_file(&mut self) {
-        unsaved_changes::save(&mut self.editor, &self.base, |editor, saved| {
+    pub fn new_file(&self) {
+        unsaved_changes::save(&self.editor, &self.base, |editor, saved| {
             if !saved {
                 return;
             }
@@ -164,7 +164,7 @@ impl EditorFrame {
     }
 
     pub fn save(&mut self) -> Result<(), ()> {
-        let path = self.editor.file.to_owned();
+        let path = self.editor.file.borrow().to_owned();
         if let Some(path) = path {
             self.save_to(&path)
         } else {
@@ -203,12 +203,12 @@ impl EditorFrame {
         });
     }
 
-    pub fn on_update_ui(&mut self, event: &wx::UpdateUIEvent) {
+    pub fn on_update_ui(&self, event: &wx::UpdateUIEvent) {
         println!("hello");
     }
 
-    pub fn on_close(&mut self, event: &wx::CloseEvent) {
-        unsaved_changes::save(&mut self.editor, &self.base, |_, saved| {
+    pub fn on_close(&self, event: &wx::CloseEvent) {
+        unsaved_changes::save(&self.editor, &self.base, |_, saved| {
             if !saved {
                 event.veto(true);
                 return;
@@ -238,7 +238,7 @@ impl EditorFrame {
     fn update_title(&self) {
         let mut modified = "";
         let mut file = UNTITLED.to_owned();
-        if let Some(path) = self.editor.file.as_ref() {
+        if let Some(path) = self.editor.file.borrow().as_ref() {
             file = path.to_owned();
         }
         if self.editor.is_modified() {

--- a/src/editor_frame.rs
+++ b/src/editor_frame.rs
@@ -52,7 +52,7 @@ impl EditorFrame {
                 let command = Command::from(event.get_id())
                     .map(|command| EditorCommand::Command(command))
                     .unwrap_or(EditorCommand::StandardEvents(event));
-                frame_copy.borrow_mut().handle_command(&command);
+                frame_copy.borrow().handle_command(&command);
             });
         let frame_copy = frame.clone();
         frame
@@ -146,8 +146,8 @@ impl EditorFrame {
         });
     }
 
-    pub fn open_file(&mut self, path: Option<&str>) {
-        unsaved_changes::save(&mut self.editor, &self.base, |editor, saved| {
+    pub fn open_file(&self, path: Option<&str>) {
+        unsaved_changes::save(&self.editor, &self.base, |editor, saved| {
             if !saved {
                 return;
             }
@@ -163,7 +163,7 @@ impl EditorFrame {
         });
     }
 
-    pub fn save(&mut self) -> Result<(), ()> {
+    pub fn save(&self) -> Result<(), ()> {
         let path = self.editor.file.borrow().to_owned();
         if let Some(path) = path {
             self.save_to(&path)
@@ -172,7 +172,7 @@ impl EditorFrame {
         }
     }
 
-    pub fn save_as(&mut self) -> Result<(), ()> {
+    pub fn save_as(&self) -> Result<(), ()> {
         let file_dialog = wx::FileDialog::builder(Some(&self.base))
             .style(wx::FC_SAVE.into())
             .build();
@@ -183,7 +183,7 @@ impl EditorFrame {
         }
     }
 
-    fn save_to(&mut self, path: &str) -> Result<(), ()> {
+    fn save_to(&self, path: &str) -> Result<(), ()> {
         // TODO: Error Handling
         if self.editor.save_to(&path) {
             Ok(())
@@ -192,7 +192,7 @@ impl EditorFrame {
         }
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         // Rust のイベント処理を引き起こして borrow rule 違反になるため
         // 1 イベント分遅らせて回避。
         let weak_frame = self.base.to_weak_ref();
@@ -249,7 +249,7 @@ impl EditorFrame {
     }
 }
 impl<'a> CommandHandler<EditorCommand<'a>> for EditorFrame {
-    fn handle_command(&mut self, editor_command: &EditorCommand<'a>) {
+    fn handle_command(&self, editor_command: &EditorCommand<'a>) {
         match editor_command {
             EditorCommand::Command(command) => match &command {
                 // ファイル

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,14 @@ fn main() {
         if let Some(file) = wx::App::args().nth(1) {
             if !Path::new(&file).exists() {
                 println!("The file {} does not exist.", file);
-                frame.borrow_mut().close();
+                frame.borrow().close();
                 return;
             }
             file_to_open = Some(file);
         }
         frame.borrow().show();
         if file_to_open.is_some() {
-            frame.borrow_mut().open_file(file_to_open.as_deref());
+            frame.borrow().open_file(file_to_open.as_deref());
         }
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,14 @@ fn main() {
         if let Some(file) = wx::App::args().nth(1) {
             if !Path::new(&file).exists() {
                 println!("The file {} does not exist.", file);
-                frame.borrow().close();
+                frame.close();
                 return;
             }
             file_to_open = Some(file);
         }
-        frame.borrow().show();
+        frame.show();
         if file_to_open.is_some() {
-            frame.borrow().open_file(file_to_open.as_deref());
+            frame.open_file(file_to_open.as_deref());
         }
     });
 }


### PR DESCRIPTION
todo!() を呼んで落ちたりするので。

UpdateUI イベントを処理して、未実装コマンドをグレーアウトするようにした。

mutabilityについて必要があり設計変更している。