### PR TITLE
Borrow rule のためだけの call_after() を削除

### DIFF
--- a/src/editor_ctrl.rs
+++ b/src/editor_ctrl.rs
@@ -33,18 +33,10 @@ impl EditorCtrl {
             .build();
         let events = Rc::new(RefCell::new(Subject::new()));
         let weak_events = Rc::downgrade(&events);
-        let textbox_copy = textbox.clone();
         textbox.bind(wx::RustEvent::Text, move |_: &wx::CommandEvent| {
-            // テキスト編集にリアルタイムで応答すると、
-            // テキスト編集を引き起こしたイベント処理内で borrow_mut() していることがあり、
-            // borrow rule に違反して panic する場合がある。
-            // テキスト編集に対するイベント処理をを1イベント分遅らせることで回避する。
-            let weak_events = weak_events.clone();
-            textbox_copy.call_after(move |_| {
-                if let Some(events) = weak_events.upgrade() {
-                    events.borrow().notify_event(DocumentEvent::TextModified);
-                }
-            });
+            if let Some(events) = weak_events.upgrade() {
+                events.borrow().notify_event(DocumentEvent::TextModified);
+            }
         });
         Self {
             ctrl: textbox,

--- a/src/editor_frame.rs
+++ b/src/editor_frame.rs
@@ -176,14 +176,7 @@ impl EditorFrame {
     }
 
     pub fn close(&self) {
-        // Rust のイベント処理を引き起こして borrow rule 違反になるため
-        // 1 イベント分遅らせて回避。
-        let weak_frame = self.base.to_weak_ref();
-        self.base.call_after(move |_| {
-            if let Some(frame) = weak_frame.get() {
-                frame.close(false);
-            }
-        });
+        self.base.close(false);
     }
 
     pub fn on_update_ui(


### PR DESCRIPTION
mutability 周りを変えたことで不要になったもの。